### PR TITLE
Fix OOB read in get_L7_from_L2 (validate header buffer size and caplen)

### DIFF
--- a/peafowl.c
+++ b/peafowl.c
@@ -282,6 +282,17 @@ NAPI_METHOD(get_L7_from_L2) {
     NAPI_ARGV_BUFFER(packet, 0);
     NAPI_ARGV_BUFFER_CAST(struct pcap_pkthdr *, header, 1);
     NAPI_ARGV_INT32(link_type, 2);
+    // Validate the header Buffer holds a full struct pcap_pkthdr before
+    // dereferencing it, and that caplen does not exceed the real packet Buffer,
+    // otherwise header->caplen / the dissection would read past the buffers.
+    if (header_len < sizeof(struct pcap_pkthdr)) {
+        napi_throw_error(env, "ERANGE", "header buffer smaller than struct pcap_pkthdr");
+        return NULL;
+    }
+    if (header->caplen > packet_len) {
+        napi_throw_error(env, "ERANGE", "header->caplen exceeds packet buffer length");
+        return NULL;
+    }
     name = _get_L7_from_L2(packet, header, link_type);
     NAPI_RETURN_STRING(name);
 }


### PR DESCRIPTION
Fixes the out-of-bounds read reported in #11.

### Problem
`get_L7_from_L2` casts argument 1 to `struct pcap_pkthdr *` without checking the Buffer is at least `sizeof(struct pcap_pkthdr)` bytes, then uses the fully caller-controlled `header->caplen` as the number of bytes to dissect from the packet Buffer — without ever comparing it against the packet Buffer's real length. Parsing an untrusted `.pcap` whose per-packet `caplen` exceeds the captured bytes makes both the header dereference and the dissection read past the end of the JS Buffers.

### Fix
In the `get_L7_from_L2` wrapper (where `env` and both Buffer lengths are available):
- reject header buffers smaller than `struct pcap_pkthdr`;
- reject `caplen` values larger than the packet Buffer;

throwing a `RangeError` before dissecting. The `NAPI_ARGV_BUFFER` / `NAPI_ARGV_BUFFER_CAST` macros already expose `packet_len` / `header_len`, so no signature changes are needed.

```js
const packet = Buffer.alloc(16);
const header = Buffer.alloc(24);
header.writeUInt32LE(0x40000000, 8);        // caplen -> ~1GB
peafowl.get_L7_from_L2(packet, header, 1);  // before: OOB read; after: throws RangeError
```