### PR TITLE
Fix OOB read in dissect_from_L2/L3/L4 (reject len larger than the packet Buffer)

### DIFF
--- a/peafowl.c
+++ b/peafowl.c
@@ -214,6 +214,12 @@ NAPI_METHOD(dissect_from_L2) {
     NAPI_ARGV_UINT32(len, 1);  // len from L2
     NAPI_ARGV_INT32(time, 2);
     NAPI_ARGV_INT32(dl, 3);    // pfwl_protocol_l2_t
+    // len is caller-supplied; reject values larger than the packet Buffer so the
+    // dissector cannot read past the end of pkt.
+    if (len > pkt_len) {
+        napi_throw_error(env, "ERANGE", "len exceeds packet buffer length");
+        return NULL;
+    }
     status = _dissect_from_L2(pkt, len, time, dl);
     NAPI_RETURN_INT32(status);
 }
@@ -224,6 +230,12 @@ NAPI_METHOD(dissect_from_L3) {
     NAPI_ARGV_BUFFER(pkt, 0);  // pkt from L3
     NAPI_ARGV_UINT32(len, 1);  // len from L3
     NAPI_ARGV_INT32(time, 2);
+    // len is caller-supplied; reject values larger than the packet Buffer so the
+    // dissector cannot read past the end of pkt.
+    if (len > pkt_len) {
+        napi_throw_error(env, "ERANGE", "len exceeds packet buffer length");
+        return NULL;
+    }
     status = _dissect_from_L3(pkt, len, time);
     NAPI_RETURN_UINT32(status);
 }
@@ -234,6 +246,12 @@ NAPI_METHOD(dissect_from_L4) {
     NAPI_ARGV_BUFFER(pkt, 0);  // pkt from L4
     NAPI_ARGV_UINT32(len, 1);  // len from L4
     NAPI_ARGV_INT32(time, 2);
+    // len is caller-supplied; reject values larger than the packet Buffer so the
+    // dissector cannot read past the end of pkt.
+    if (len > pkt_len) {
+        napi_throw_error(env, "ERANGE", "len exceeds packet buffer length");
+        return NULL;
+    }
     status = _dissect_from_L4(pkt, len, time);
     NAPI_RETURN_UINT32(status);
 }


### PR DESCRIPTION
Fixes the out-of-bounds read reported in #12.

### Problem
`dissect_from_L2`, `dissect_from_L3` and `dissect_from_L4` take the packet as a JS `Buffer` (argument 0) plus a *separate*, unvalidated numeric length (argument 1), and forward that length straight to the peafowl dissector as the number of bytes to parse. The Buffer's real length is never consulted, so any `len` larger than the Buffer causes an out-of-bounds read whose parse results are returned to JS.

### Fix
In all three wrappers, reject `len` values larger than the packet Buffer (`pkt_len`, already produced by `NAPI_ARGV_BUFFER`) with a thrown `RangeError` before dissecting.

```js
const pkt = Buffer.alloc(32);
peafowl.dissect_from_L3(pkt, 0x10000000, 0);  // before: OOB read; after: throws RangeError
```